### PR TITLE
update url

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -4,13 +4,13 @@
     <description>
         Cyd Ynni app to show hydro status
     </description>
-    <author email="david@inferiorplanet.co.uk" href="http://lab.megni.co.uk/cydynni/">
+    <author email="david@inferiorplanet.co.uk" href="http://cydynni.org.uk/">
         David Hunnisett
     </author>
     <content src="index.html"/>
     <plugin name="cordova-plugin-whitelist" spec="1"/>
-    <access origin="http://lab.megni.co.uk/cydynni/*"/>
-    <allow-navigation href="http://lab.megni.co.uk/*"/>
+    <access origin="http://cydynni.org.uk/*"/>
+    <allow-navigation href="http://cydynni.org.uk/*"/>
     <allow-intent href="http://*/*"/>
     <allow-intent href="https://*/*"/>
     <allow-intent href="tel:*"/>


### PR DESCRIPTION
- App needs to use production server rather than dev server for data access

Currently user login and personal data access will not work. Sorry, my fault. Was not aware Trystan had launched the app on the production server. 

Do you want to keep your name and email in there or would you like to change to use `support@openenergymonitor.zendesk.com` ? 
